### PR TITLE
MQTT server URL option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # adt-pulse-mqtt
 ADT Pulse bridge for Home Assistant using MQTT
+
+
+This project is deprecated, check out https://github.com/haruny/adt-pulse-mqtt.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ SmartApp allows automatic running our Routines upon alarm changing states.
 ## Hassio Setup
 Add the repository (https://github.com/haruny/adt-pulse-mqtt/) to Hassio.
 Hit Install. Don't forget to configure `pulse_login` with your ADT Pulse Portal username and password. I recommend using a separate login for Home Assistant use. 
-You'll need an MQTT broker to run this. I'm using Mosquitto broker (https://www.home-assistant.io/addons/mosquitto/)
+You'll need an MQTT broker to run this. I'm using Mosquitto broker (https://www.home-assistant.io/addons/mosquitto/).
+
+In most cases, the mqtt_host option and the mqtt username and password options are sufficient. 
+For advanced confgurations, you may want to use the mqtt_url option instead. Additional connections options are available (see https://www.npmjs.com/package/mqtt#connect).
 
 ### Configuration
 Change the config of the app in hassio then edit the configuration.yaml:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,2 @@
 # adt-pulse-mqtt
 ADT Pulse bridge for Home Assistant using MQTT
-
-
-This project is deprecated, check out https://github.com/haruny/adt-pulse-mqtt.

--- a/adt-pulse-mqtt/config.json
+++ b/adt-pulse-mqtt/config.json
@@ -23,7 +23,7 @@
         "username": "",
         "password": ""
       },
-      "mqtt_host" :  "core-mosquitto",
+      "mqtt_url" :  "mqtt://core-mosquitto",
       "mqtt_connect_options" :  {
         "username" : "",
         "password" : ""
@@ -42,7 +42,7 @@
         "username": "str",
         "password": "str"
       },
-      "mqtt_host" : "str",
+      "mqtt_url" : "str",
       "mqtt_connect_options" : {
          "username" : "str",
          "password" : "str"

--- a/adt-pulse-mqtt/config.json
+++ b/adt-pulse-mqtt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "ADT Pulse MQTT",
-  "version": "0.2.2.6",
+  "version": "0.2.2.7",
   "slug": "adt-pulse-mqtt",
   "description": "ADT Pulse Bridge using MQTT",
   "url":"https://github.com/haruny/adt-pulse-mqtt",
@@ -23,8 +23,9 @@
         "username": "",
         "password": ""
       },
-      "mqtt_url" :  "mqtt://core-mosquitto",
-      "mqtt_connect_options" :  {
+      "mqtt_host" : "core-mosquitto",
+	  "mqtt_url" : "",
+	  "mqtt_connect_options" :  {
         "username" : "",
         "password" : ""
       },
@@ -42,8 +43,9 @@
         "username": "str",
         "password": "str"
       },
-      "mqtt_url" : "str",
-      "mqtt_connect_options" : {
+       "mqtt_host" : "str",
+	   "mqtt_url" : "str?",
+       "mqtt_connect_options" : {
          "username" : "str",
          "password" : "str"
       },

--- a/adt-pulse-mqtt/server.js
+++ b/adt-pulse-mqtt/server.js
@@ -3,7 +3,7 @@ const mqtt = require('mqtt');
 var config = require('/data/options.json');
 
 var myAlarm = new Pulse(config.pulse_login.username, config.pulse_login.password);
-var client = new mqtt.connect("mqtt://"+config.mqtt_host,config.mqtt_connect_options);
+var client = new mqtt.connect(config.mqtt_url, config.mqtt_options);
 var alarm_state_topic = config.alarm_state_topic;
 var alarm_command_topic = config.alarm_command_topic;
 var zone_state_topic = config.zone_state_topic;

--- a/adt-pulse-mqtt/server.js
+++ b/adt-pulse-mqtt/server.js
@@ -3,7 +3,15 @@ const mqtt = require('mqtt');
 var config = require('/data/options.json');
 
 var myAlarm = new Pulse(config.pulse_login.username, config.pulse_login.password);
-var client = new mqtt.connect(config.mqtt_url, config.mqtt_options);
+
+// Use mqtt_url option if specified, otherwise build URL using host option
+if (config.mqtt_url) {
+   var client = new mqtt.connect(config.mqtt_url, config.mqtt_options); 
+}
+else {
+   var client = new mqtt.connect("mqtt://"+config.mqtt_host,config.mqtt_connect_options);
+}
+
 var alarm_state_topic = config.alarm_state_topic;
 var alarm_command_topic = config.alarm_command_topic;
 var zone_state_topic = config.zone_state_topic;

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd adt-pulse-mqtt
+docker build --build-arg BUILD_FROM="homeassistant/amd64-base:latest" -t local/adt-pulse-mqtt .


### PR DESCRIPTION
I'm not using Hassio, but instead running individual Docker containers on my QNAP NAS and I had trouble connecting to my mosquitto container. I switched to specifying a URL in the options instead of building a URL in the mqtt.connect and added a few more entries to mqtt_connect_options to make it work.  

I didn't include these extra options in my commit because not running as a hassio addon means I don't need to use config.json. I just created my own options.json in the container config directory. If these additional options are of interest, I'll be happy to share.

Since the mqtt library supports several different protocols, the URL options allows for more variety in configurations. My goal is to make a secure connection to mosquitto using the same self-signed client certificate I use with my Owntracks clients. For now I set up a second, non-SSL listener in mosquitto.